### PR TITLE
Add safeHTML filter to post summary

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
       <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
       <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
       <div class="content">
-        {{ .Summary | plainify }}
+        {{ .Summary | plainify | safeHTML }}
         {{ if .Truncated }}
         ...<a class="button is-link" href="{{ .Permalink }}" style="height:28px">
           Read more


### PR DESCRIPTION
Without safeHTML, html entities for normal text (like quotes and other punctuation) will be displayed.
