### PR TITLE
Use baseurl property for css

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{ .Title }}{{ if eq .IsHome false }} | {{ .Site.Title }}{{ end }}</title>
-<link rel="stylesheet" href="/css/style.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
 {{ with .Site.Params.highlight.style }}
 <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ . }}.min.css">


### PR DESCRIPTION
Without this change the template doesn't work for baseurls
that aren't at the root of the domain. E.g.
'http://example.com/foo/bar' leads to a 404 looking for
http://example.com/css/style.css.
