### PR TITLE
Use built-in google analytics code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Copy the `config.toml` in the root directory of your website. Overwrite the exis
 __[config.toml](https://github.com/tanksuzuki/hemingway/blob/master/exampleSite/config.toml)__:
 
 ```toml
-baseurl = "http://replace-this-with-your-hugo-site.com"
+baseurl = "https://example.com"
 languageCode = "en"
 title = "Hemingway"
 theme = "hemingway"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,13 @@
+<section class="section">
+  <div class="container has-text-centered">
+    <p>{{ .Site.Copyright | safeHTML }}</p>
+  </div>
+</section>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+{{ range .Site.Params.highlight.languages }}
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/languages/{{ . }}.min.js"></script>
+{{ end }}
+<script>hljs.initHighlightingOnLoad();</script>
 {{ if .Site.GoogleAnalytics }}
 {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,15 +1,3 @@
-<section class="section">
-  <div class="container has-text-centered">
-    <p>{{ .Site.Copyright | safeHTML }}</p>
-  </div>
-</section>
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
-{{ range .Site.Params.highlight.languages }}
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/languages/{{ . }}.min.js"></script>
-{{ end }}
-<script>hljs.initHighlightingOnLoad();</script>
-{{ with .Site.GoogleAnalytics }}
-<script>
-!function(a,b,c,d,e,f,g){a.GoogleAnalyticsObject=e,a[e]=a[e]||function(){(a[e].q=a[e].q||[]).push(arguments)},a[e].l=1*new Date,f=b.createElement(c),g=b.getElementsByTagName(c)[0],f.async=1,f.src=d,g.parentNode.insertBefore(f,g)}(window,document,"script","//www.google-analytics.com/analytics.js","ga"),ga("create","{{ . }}","auto"),ga("send","pageview");
-</script>
+{{ if .Site.GoogleAnalytics }}
+{{ template "_internal/google_analytics_async.html" . }}
 {{ end }}


### PR DESCRIPTION
Using the built-in google analytics code that was introduced in v0.16, the minimum version supported by this theme.