### PR TITLE
Fix missing html tags and add favicon config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ disqusShortname = "shortname"
 googleAnalytics = ""
 
 [params]
+favicon = "https://assets-cdn.github.com/favicon.ico"
 
 [params.highlight]
 style = "github"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -10,3 +10,4 @@
     </div>
   </div>
 </section>
+{{ partial "footer" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,1 +1,1 @@
-<!-- This theme is not supported list page -->
+{{ template "theme/index.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,6 +2,11 @@
 {{ partial "nav" . }}
 <section class="section">
   <div class="container">
+    <div class="subtitle is-6 is-pulled-right">
+      {{ if .Params.tags }}
+      {{ partial "tags" .Params.tags }}
+      {{ end }}
+    </div>
     <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
     <h1 class="title">{{ .Title }}</h1>
     <div class="content">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,6 +4,11 @@
   <div class="container">
     {{ range sort .Paginator.Pages }}
     <article>
+      <div class="subtitle is-6 is-pulled-right">
+        {{ if .Params.tags }}
+        {{ partial "tags" .Params.tags }}
+        {{ end }}
+      </div>
       <h2 class="subtitle is-6">{{ .Date.Format "January 2, 2006" }}</h2>
       <h1 class="title"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if .Draft }} ::Draft{{ end }}</h1>
       <div class="content">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,3 +11,6 @@
 {{ if .Site.GoogleAnalytics }}
 {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
+
+</body>
+</html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,12 +1,18 @@
 <!DOCTYPE html>
-<html{{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<html xmlns="http://www.w3.org/1999/xhtml" {{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>{{ .Title }}{{ if eq .IsHome false }} | {{ .Site.Title }}{{ end }}</title>
-<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css">
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css">
+<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/style.css" />
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" />
 {{ with .Site.Params.highlight.style }}
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ . }}.min.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ . }}.min.css" />
 {{ else }}
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css" />
 {{ end }}
+{{ with .Site.Params.favicon }}
+<link rel="icon" type="image/x-icon" href="{{ . }}">
+{{ end }}
+</head>
+<body>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -2,6 +2,8 @@
 <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
 {{ end }}
 
-{{ range after 1 . }}
-| <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+{{ if gt (len .) 1 }}
+  {{ range after 1 . }}
+  | <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+  {{ end }}
 {{ end }}

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,0 +1,7 @@
+{{ range first 1 . }}
+<a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+{{ end }}
+
+{{ range after 1 . }}
+| <a class="subtitle is-6" href="{{ "/tags/" | relURL }}{{ . | urlize }}">#{{ . }}</a>
+{{ end }}


### PR DESCRIPTION
Add missing `<head>`, `<body>` and closing `</html>` tags in generated html file.

This PR also contains previous tag support PR (#12).
